### PR TITLE
Fixes security issue with ajax calls

### DIFF
--- a/src/views/admin-settings.php
+++ b/src/views/admin-settings.php
@@ -62,7 +62,7 @@
 <script>
 
 /**
- * @license Copyright 2011-2015 BitPay Inc., MIT License 
+ * @license Copyright 2011-2015 BitPay Inc., MIT License
  * see https://github.com/bitpay/woocommerce-bitpay/blob/master/LICENSE
  */
 
@@ -106,7 +106,8 @@
       $.post(ajaxurl, {
         'action':       'bitpay_pair_code',
         'pairing_code': $('.bitpay-pairing__code').val(),
-        'network':      $('.bitpay-pairing__network').val()
+        'network':      $('.bitpay-pairing__network').val(),
+        'pairNonce':    '<?php echo wp_create_nonce( 'bitpay-pair-nonce' ); ?>'
       })
       .done(function (data) {
 
@@ -133,7 +134,7 @@
           $('#message').remove();
           $('#gform_tab_group').before('<div id="message" class="error"><p><strong>Unable to pair with BitPay</strong></p></div>');
         }
-        
+
       });
     });
 
@@ -145,7 +146,8 @@
 
       if (confirm('Are you sure you want to revoke the token?')) {
         $.post(ajaxurl, {
-          'action': 'bitpay_revoke_token'
+          'action':      'bitpay_revoke_token',
+          'revokeNonce': '<?php echo wp_create_nonce( 'bitpay-revoke-nonce' ); ?>'
         })
         .always(function (data) {
           $('.bitpay-token').fadeOut(500, function () {


### PR DESCRIPTION
WordPress's wp-admin/admin-ajax.php doesn't check permissions of users
to verify administrator privileges.  Therefore, any logged in user
could utilize the ajax calls for managing BitPay tokens used
by the plugin.

All ajax calls now include nonces to protect against CSRF
and check the user permissions for the ability to manage options.
